### PR TITLE
fix: naprawienie deprekacji http_build_query

### DIFF
--- a/src/Hmac/RequestSigner.php
+++ b/src/Hmac/RequestSigner.php
@@ -60,7 +60,7 @@ class RequestSigner
     {
         $parameters = $this->sortSignatureParams($parameters);
 
-        $queryString = http_build_query($parameters, null, '&', PHP_QUERY_RFC3986);
+        $queryString = http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
         $signatureBase = strtoupper('POST') .
             '&' . rawurlencode($this->getUrl($requestUri)) . '&' . rawurlencode($queryString);
 


### PR DESCRIPTION
Aktualizacja prefixa z nulla na pusty string aby pozbyć się deprekacji http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated